### PR TITLE
Åpne sang i Spotify

### DIFF
--- a/cms/schemas/documents/song.js
+++ b/cms/schemas/documents/song.js
@@ -46,6 +46,11 @@ const song = {
       type: "number",
     },
     {
+      title: "Spotify URI",
+      name: "spotifyuri",
+      type: "string",
+    },
+    {
       name: "slug",
       type: "slug",
       title: "Slug",

--- a/cms/schemas/documents/song.js
+++ b/cms/schemas/documents/song.js
@@ -49,6 +49,8 @@ const song = {
       title: "Spotify URI",
       name: "spotifyuri",
       type: "string",
+      description:
+        "Lenke for å åpne en sang direkte i installert Spotify klient (https://community.spotify.com/t5/Spotify-Answers/What-s-a-Spotify-URI/ta-p/919201)",
     },
     {
       name: "slug",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2049,6 +2049,15 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -4240,6 +4249,12 @@
                 "flat-cache": "^3.0.4"
             }
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "optional": true
+        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6247,6 +6262,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "optional": true
         },
         "nano-pubsub": {
             "version": "1.0.2",
@@ -9309,7 +9330,11 @@
                     "version": "1.2.13",
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "3.1.0",

--- a/frontend/src/api/songs.ts
+++ b/frontend/src/api/songs.ts
@@ -17,6 +17,7 @@ export const SONG_DETAIL_QUERY = groq`
     chorus,
     title,
     verses,
+    spotifyuri,
     "category" : category -> name,
     'info': {
       'prev': *[_type=='song' && numbering==^.numbering-1][0].slug.current,
@@ -49,4 +50,5 @@ export interface SongDetailType {
   category: string;
   info: Info;
   chorus: string;
+  spotifyuri: string;
 }

--- a/frontend/src/components/molecules/HeaderDetails.tsx
+++ b/frontend/src/components/molecules/HeaderDetails.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Box, Button, Heading, IconButton, Link, Text } from "@chakra-ui/react";
+import { Box, Heading, Link, Text } from "@chakra-ui/react";
 import { FaSpotify } from "react-icons/fa";
 interface HeaderDetailsProps {
   title: string;
@@ -13,8 +13,6 @@ const HeaderDetails: FC<HeaderDetailsProps> = ({
   melody,
   spotifyuri,
 }) => {
-  console.log(spotifyuri);
-
   return (
     <Box p="2.5rem 2.5rem 1.5rem">
       <Heading fontWeight="300" as="h1" size="xl">

--- a/frontend/src/components/molecules/HeaderDetails.tsx
+++ b/frontend/src/components/molecules/HeaderDetails.tsx
@@ -1,12 +1,20 @@
-import { Box, Heading, Text } from "@chakra-ui/react";
 import React, { FC } from "react";
-
+import { Box, Button, Heading, IconButton, Link, Text } from "@chakra-ui/react";
+import { FaSpotify } from "react-icons/fa";
 interface HeaderDetailsProps {
   title: string;
   author: string;
   melody: string;
+  spotifyuri: string;
 }
-const HeaderDetails: FC<HeaderDetailsProps> = ({ title, author, melody }) => {
+const HeaderDetails: FC<HeaderDetailsProps> = ({
+  title,
+  author,
+  melody,
+  spotifyuri,
+}) => {
+  console.log(spotifyuri);
+
   return (
     <Box p="2.5rem 2.5rem 1.5rem">
       <Heading fontWeight="300" as="h1" size="xl">
@@ -18,6 +26,11 @@ const HeaderDetails: FC<HeaderDetailsProps> = ({ title, author, melody }) => {
       <Text fontSize="sm" fontWeight="light">
         Melodi: {melody}
       </Text>
+      {spotifyuri ? (
+        <Link href={spotifyuri}>
+          <FaSpotify />
+        </Link>
+      ) : null}
     </Box>
   );
 };

--- a/frontend/src/components/organisms/SongDetail.tsx
+++ b/frontend/src/components/organisms/SongDetail.tsx
@@ -35,8 +35,6 @@ const SongDetail: FC<SongDetailProps> = ({ song, onSwipe }) => {
 
   const [songType, setSongType] = useState<SongTypes>();
 
-  console.log("Spotify", spotifyuri);
-
   useEffect(() => {
     setSongType(getSongType(song));
   }, [song]);

--- a/frontend/src/components/organisms/SongDetail.tsx
+++ b/frontend/src/components/organisms/SongDetail.tsx
@@ -31,9 +31,11 @@ const getSongType = (song: SongDetailType) => {
 };
 
 const SongDetail: FC<SongDetailProps> = ({ song, onSwipe }) => {
-  const { author, title, melody } = song;
+  const { author, title, melody, spotifyuri } = song;
 
   const [songType, setSongType] = useState<SongTypes>();
+
+  console.log("Spotify", spotifyuri);
 
   useEffect(() => {
     setSongType(getSongType(song));
@@ -43,7 +45,12 @@ const SongDetail: FC<SongDetailProps> = ({ song, onSwipe }) => {
     <>
       <Header color="#D6F2E6">
         <Heading>
-          <HeaderDetails title={title} author={author} melody={melody} />
+          <HeaderDetails
+            title={title}
+            author={author}
+            melody={melody}
+            spotifyuri={spotifyuri}
+          />
         </Heading>
       </Header>
 


### PR DESCRIPTION
Implementert:
- Mulighet for å legge til en [Spotify URI](https://community.spotify.com/t5/Spotify-Answers/What-s-a-Spotify-URI/ta-p/919201) tilknyttet en sang i backend. Det lar brukeren direkte åpne Spotify applikasjonen på enheten, på sangen som er angitt i URI'en.
- Knapp i `HeaderDetails` for å gå til sangen i Spotify

Avventer med plassering av element i påvente av #7 

Closes #10 